### PR TITLE
rename package to node-documentation-generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
-  "name": "node-doc-generator",
+  "name": "node-documentation-generator",
   "description": "Internal tool for generating Node.js API docs",
   "version": "0.0.0",
   "engines": {


### PR DESCRIPTION
like the repo name
