### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,18 +3,21 @@
   "name": "node-doc-generator",
   "description": "Internal tool for generating Node.js API docs",
   "version": "1.0.0",
-  "engines": {
-    "node": ">=0.6.10"
-  },
   "scripts": {
     "test": "lab -v"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joyent/node-documentation-generator"
   },
   "dependencies": {
     "marked": "~0.1.9"
   },
+  "bundleDependencies": [
+    "marked"
+  ],
   "devDependencies": {
     "lab": "~5.2.1"
   },
-  "optionalDependencies": {},
   "bin": "./generate.js"
 }


### PR DESCRIPTION
- marked is a bundled dep as it got patched some years ago,
  this ensures our patched version is used, see
  nodejs/nodejs.org#84
- add repo url to remove warning
- remove superfluous optional-deps key
